### PR TITLE
Add support for DXT1 in RGBA8888 converter

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,6 +244,8 @@ const VTFImageData = exports.VTFImageData = class VTFImageData {
 				return Buffer.from(dxt.decompress(from, this.Width, this.Height, dxt.flags.DXT5));
 			case "DXT3":
 				return Buffer.from(dxt.decompress(from, this.Width, this.Height, dxt.flags.DXT3));
+			case "DXT1":
+				return Buffer.from(dxt.decompress(from, this.Width, this.Height, dxt.flags.DXT1));
 			
 			case "ABGR8888":
 				data = Buffer.from(from);


### PR DESCRIPTION
Hi!

First off, thanks for writing this module! It has saved me a tremendous amount of time.
When I was reading some VTF files, specifically CSGO's, I noticed that some were encoded with DXT1.
I added a case in the RGBA8888 converter to handle these.